### PR TITLE
(Feat): New metric for tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ on how to build your own image and push it to your private registry.
 | `pingdom_up_seconds`                                | Total up time within the outage check period, in seconds                        |
 | `pingdom_uptime_slo_error_budget_total_seconds`     | Maximum number of allowed downtime, in seconds, according to the uptime SLO     |
 | `pingdom_uptime_slo_error_budget_available_seconds` | Number of seconds of downtime we can still have without breaking the uptime SLO |
+| `pingdom_tags`                                      | The current tags of the check                                                   |
 
 ## Development
 

--- a/pkg/pingdom-exporter/api_responses.go
+++ b/pkg/pingdom-exporter/api_responses.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"regexp"
 	"strconv"
-	"strings"
 )
 
 // Uptime SLO tag format.
@@ -78,7 +77,7 @@ type CheckResponseType struct {
 type CheckResponseTag struct {
 	Name  string      `json:"name"`
 	Type  string      `json:"type"`
-	Count interface{} `json:"count"`
+	Count float64     `json:"count"`
 }
 
 // SummaryPerformanceResponse represents the JSON response for a summary performance from the Pingdom API.
@@ -162,13 +161,9 @@ func (r *Error) Error() string {
 	return fmt.Sprintf("%d %v: %v", r.StatusCode, r.StatusDesc, r.Message)
 }
 
-// TagsString returns the check tags as a comma-separated string.
-func (cr *CheckResponse) TagsString() string {
-	var tagsRaw []string
-	for _, tag := range cr.Tags {
-		tagsRaw = append(tagsRaw, tag.Name)
-	}
-	return strings.Join(tagsRaw, ",")
+// Tags returns the check tags.
+func (cr *CheckResponse) AllTags() []CheckResponseTag {
+	return cr.Tags
 }
 
 // HasIgnoreTag returns true if the tag "pingdom_exporter_ignored" exists for

--- a/pkg/pingdom-exporter/api_responses_test.go
+++ b/pkg/pingdom-exporter/api_responses_test.go
@@ -11,22 +11,34 @@ func TestErrorError(t *testing.T) {
 	assert.Equal(t, "200 OK: Message", errorResponse.Error())
 }
 
-func TestCheckResponseTagsString(t *testing.T) {
-	checkResponse := CheckResponse{
-		Tags: []CheckResponseTag{
-			{
+func TestCheckResponseAllTags(t *testing.T) {
+	testCases := []struct {
+		tag      CheckResponseTag
+		expected bool
+	}{
+		{
+			tag: CheckResponseTag{
 				Name:  "apache",
 				Type:  "a",
 				Count: 2,
 			},
-			{
+		},
+		{
+			tag: CheckResponseTag{
 				Name:  "server",
 				Type:  "a",
 				Count: 2,
 			},
 		},
 	}
-	assert.Equal(t, "apache,server", checkResponse.TagsString())
+
+	for _, testCase := range testCases {
+		response := CheckResponse{
+			Tags: []CheckResponseTag{testCase.tag},
+		}
+		actual := response.AllTags()
+		assert.Equal(t, actual[0].Name, testCase.tag.Name)
+	}
 }
 
 func TestHasIgnoredTag(t *testing.T) {


### PR DESCRIPTION
This change aims to add a new metric that relates the checkid to a tag.

This way, we will have a record for each tag related to a check id, so that we can filter specific checks by tag, thus eliminating the need to parse the list of tags that was returned in each metric.