### PR TITLE
(feat): New metric that populates data based on a tag format

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,23 +61,23 @@ the given tags.
 
 ### Docker Image
 
-We no longer provide a public Docker image. See the **Development** section
-on how to build your own image and push it to your private registry.
+Docker image tags are published to [GHCR](https://github.com/kokuwaio/pingdom-exporter/pkgs/container/pingdom-exporter) as changes are incorporated into the main branch.
 
 ## Exported Metrics
 
-| Metric Name                                         | Description                                                                     |
-| --------------------------------------------------- | ------------------------------------------------------------------------------- |
-| `pingdom_up`                                        | Was the last query on Pingdom API successful                                    |
-| `pingdom_uptime_status`                             | The current status of the check (1: up, 0: down)                                |
-| `pingdom_uptime_response_time_seconds`              | The response time of last test, in seconds                                      |
-| `pingdom_slo_period_seconds`                        | Outage check period, in seconds (see `-outage-check-period` flag)               |
-| `pingdom_outages_total`                             | Number of outages within the outage check period                                |
-| `pingdom_down_seconds`                              | Total down time within the outage check period, in seconds                      |
-| `pingdom_up_seconds`                                | Total up time within the outage check period, in seconds                        |
-| `pingdom_uptime_slo_error_budget_total_seconds`     | Maximum number of allowed downtime, in seconds, according to the uptime SLO     |
-| `pingdom_uptime_slo_error_budget_available_seconds` | Number of seconds of downtime we can still have without breaking the uptime SLO |
-| `pingdom_tags`                                      | The current tags of the check                                                   |
+| Metric Name                                         | Description                                                                                                   |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `pingdom_down_seconds`                              | Total down time within the outage check period, in seconds                                                    |
+| `pingdom_outages_total`                             | Number of outages within the outage check period                                                              |
+| `pingdom_slo_period_seconds`                        | Outage check period, in seconds (see `-outage-check-period` flag)                                             |
+| `pingdom_tags_label`                                | Formats a tag based on a regular expression (`-parser-tags` and `-tag-format`) (1: formatted, 0: unformatted) |
+| `pingdom_tags`                                      | The current tags of the check                                                                                 |
+| `pingdom_up_seconds`                                | Total up time within the outage check period, in seconds                                                      |
+| `pingdom_up`                                        | Was the last query on Pingdom API successful                                                                  |
+| `pingdom_uptime_response_time_seconds`              | The response time of last test, in seconds                                                                    |
+| `pingdom_uptime_slo_error_budget_available_seconds` | Number of seconds of downtime we can still have without breaking the uptime SLO                               |
+| `pingdom_uptime_slo_error_budget_total_seconds`     | Maximum number of allowed downtime, in seconds, according to the uptime SLO                                   |
+| `pingdom_uptime_status`                             | The current status of the check (1: up, 0: down)                                                              |
 
 ## Development
 

--- a/pkg/pingdom-exporter/utils.go
+++ b/pkg/pingdom-exporter/utils.go
@@ -1,0 +1,29 @@
+package pingdom
+
+import (
+	"regexp"
+)
+
+type tagByLabel struct {
+	LabelKey   string
+	LabelValue string
+	Formatted  int
+}
+
+func TagLabel(n string, f string) (tagByLabel, error) {
+	regex, err := regexp.Compile(f)
+	tl := tagByLabel{LabelKey: "", LabelValue: "", Formatted: 0}
+
+	if err != nil {
+		return tl, err
+	}
+
+	matches := regex.FindAllStringSubmatch(n, -1)
+
+	if len(matches) > 0 {
+		tl.LabelKey = matches[0][1]
+		tl.LabelValue = matches[0][2]
+		tl.Formatted = 1
+	}
+	return tl, nil
+}

--- a/pkg/pingdom-exporter/utils_test.go
+++ b/pkg/pingdom-exporter/utils_test.go
@@ -1,0 +1,32 @@
+package pingdom
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTagLabel(t *testing.T) {
+	testCases := []struct {
+		tag string
+		regex string
+	}{
+		{
+			tag: "key:value",
+			regex: "^([a-zA-Z0-9_]+):(.+)$",
+		},
+		{
+			tag: "key-value",
+			regex: "^([a-zA-Z0-9_]+)-(.+)$",
+		},
+		{
+			tag: "key@value",
+			regex: "^([a-zA-Z0-9_]+)@(.+)$",
+		},
+	}
+
+	for _, testCase := range testCases {
+		result, _ := TagLabel(testCase.tag, testCase.regex)
+		assert.Equal(t, result.Formatted, 1)
+	}
+}


### PR DESCRIPTION
This change aims to add a new metric to handle tag values.

When a tag has a known format, we can configure the exporter to parse the tag and create a metric that has a labelKey and a labelValue based on a regular expression.

When the parsing is successful, the metric returns the value 1, otherwise, it returns the value zero.

When this functionality is enabled, the pingdom_tags metric is no longer created and the pingdon_tags_label tag is created, still maintaining a tag label in the metric.