### PR TITLE
(Feat): Add Support for Custom Label Formatting and Extra Labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ BIN=pingdom-exporter
 IMAGE=kokuwaio/$(BIN)
 DOCKER_BIN=docker
 
+SRC_DIR = .
+GOFMT := gofmt
+GOFMT_FLAGS := -s -w
+
 TAG=$(shell git describe --tags)
 
 .PHONY: build
@@ -11,19 +15,19 @@ build:
 
 .PHONY: test
 test:
-	go vet ./...
-	go test -coverprofile=coverage.out ./...
+	go vet $(SRC_DIR)/...
+	go test -coverprofile=coverage.out $(SRC_DIR)/...
 	go tool cover -func=coverage.out
 
 .PHONY: lint
 lint:
 	go install golang.org/x/lint/golint@latest
-	golint ./...
+	golint $(SRC_DIR)/...
 
 # Build the Docker build stage TARGET
 .PHONY: image
 image:
-	$(DOCKER_BIN) build -t $(IMAGE):$(TAG) .
+	$(DOCKER_BIN) build -t $(IMAGE):$(TAG) $(SRC_DIR)
 
 # Push Docker images to the registry
 .PHONY: publish
@@ -31,3 +35,6 @@ publish:
 	$(DOCKER_BIN) push $(IMAGE):$(TAG)
 	$(DOCKER_BIN) tag $(IMAGE):$(TAG) $(IMAGE):latest
 	$(DOCKER_BIN) push $(IMAGE):latest
+
+fmt:
+	$(GOFMT) $(GOFMT_FLAGS) $(SRC_DIR)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Usage of bin/pingdom-exporter:
       Enable tag formatting based on a regular expression
   -port int
       port to listen on (default 9158)
+  -tag-extra-labels string
+      Extra labels to be added to the tags
   -tag-format string
       Regular expression used to format tags. (default "^([a-zA-Z0-9_]+):(.+)$")
   -tags string
@@ -63,14 +65,28 @@ metrics.
 You can also set the `-tags` flag to only return metrics for checks that contain
 the given tags.
 
+##### `-parser-tags`, `-tag-format` and `-tag-extra-labels` flag
 
-##### `-parser-tags` and `-tag-format` flag
-
-When this flag is enabled, the `pingdom_tags` metric will no longer be generated in favor of the `pingdom_tags_label` metric.
+When the `-parser-tags` flag is enabled, the `pingdom_tags` metric will no longer be generated in favor of the `pingdom_tags_label` metric.
 
 With this flag, the tag will be formatted based on the regular expression specified in the `-tag-format` flag.
 
-If the tag is formatted correctly, the metric returns the value `1`, if not, it returns the value `0`.
+If the tag is formatted correctly, the metric returns the value `1`; if not, it returns the value `0`.
+
+Additionally, the `-tag-extra-labels` flag allows extracting extra labels from tags.
+The labels must be specified as a comma-separated list, and each extracted label is converted to snake_case and prefixed with `label_`.
+
+For example, using:
+
+```shell
+-tag-extra-labels="region,team"
+```
+
+A Pingdom tag like `region:us-east` would result in the following metric:
+
+```bash
+pingdom_tags_label{id="123", label_region="us-east"}
+```
 
 ### Docker Image
 

--- a/pkg/pingdom-exporter/api_responses.go
+++ b/pkg/pingdom-exporter/api_responses.go
@@ -75,9 +75,9 @@ type CheckResponseType struct {
 
 // CheckResponseTag is an optional tag that can be added to checks.
 type CheckResponseTag struct {
-	Name  string      `json:"name"`
-	Type  string      `json:"type"`
-	Count float64     `json:"count"`
+	Name  string  `json:"name"`
+	Type  string  `json:"type"`
+	Count float64 `json:"count"`
 }
 
 // SummaryPerformanceResponse represents the JSON response for a summary performance from the Pingdom API.
@@ -161,7 +161,7 @@ func (r *Error) Error() string {
 	return fmt.Sprintf("%d %v: %v", r.StatusCode, r.StatusDesc, r.Message)
 }
 
-// Tags returns the check tags.
+// AllTags returns all tags associated with the check.
 func (cr *CheckResponse) AllTags() []CheckResponseTag {
 	return cr.Tags
 }

--- a/pkg/pingdom-exporter/utils.go
+++ b/pkg/pingdom-exporter/utils.go
@@ -1,18 +1,27 @@
 package pingdom
 
 import (
+	"fmt"
 	"regexp"
+	"strings"
+	"unicode"
 )
 
-type tagByLabel struct {
+// TagByLabel represents a structured tag with a key, value, and format flag.
+type TagByLabel struct {
 	LabelKey   string
 	LabelValue string
 	Formatted  int
 }
 
-func TagLabel(n string, f string) (tagByLabel, error) {
+// ExtraLabel represents a mapping of custom labels with their corresponding values.
+type ExtraLabel map[string]string
+
+// TagLabel extracts a label key and value from a given string using a regex pattern.
+// It returns a TagByLabel struct containing the extracted key, value, and a formatting flag.
+func TagLabel(n string, f string) (TagByLabel, error) {
 	regex, err := regexp.Compile(f)
-	tl := tagByLabel{LabelKey: "", LabelValue: "", Formatted: 0}
+	tl := TagByLabel{LabelKey: "", LabelValue: "", Formatted: 0}
 
 	if err != nil {
 		return tl, err
@@ -26,4 +35,73 @@ func TagLabel(n string, f string) (tagByLabel, error) {
 		tl.Formatted = 1
 	}
 	return tl, nil
+}
+
+// toSnakeCase converts a string to snake_case format.
+func toSnakeCase(input string) string {
+	var sb strings.Builder
+
+	// Iterate over each character in the input string.
+	for i, r := range input {
+		// Check if the character is an uppercase letter.
+		if unicode.IsUpper(r) {
+			// Add an underscore before uppercase letters (except at the beginning) and convert to lowercase.
+			if i > 0 && (unicode.IsLetter(r) || unicode.IsDigit(r)) {
+				sb.WriteRune('_')
+			}
+			r = unicode.ToLower(r)
+		}
+		sb.WriteRune(r)
+	}
+
+	// Clean non-alphanumeric characters and consecutive underscores.
+	result := sb.String()
+	result = regexp.MustCompile(`[^a-zA-Z0-9]+`).ReplaceAllString(result, "_")
+	result = regexp.MustCompile(`_{2,}`).ReplaceAllString(result, "_")
+
+	// Trim leading/trailing underscores.
+	return strings.Trim(result, "_")
+}
+
+// ProcessExtraLabels converts a comma-separated string of labels into a map where
+// the key is the original label and the value is its snake_case version.
+// It also returns the list of keys in the order they were processed.
+func ProcessExtraLabels(labels string) (ExtraLabel, []string) {
+	extraLabels := make(ExtraLabel)
+	var labelOrder []string
+
+	// Split the input string by commas and process each label.
+	for _, label := range strings.Split(labels, ",") {
+		trimmedLabel := strings.TrimSpace(label)
+		if trimmedLabel != "" {
+			// Store the label in snake_case format
+			snakeLabel := fmt.Sprintf("label_%s", toSnakeCase(trimmedLabel))
+			extraLabels[trimmedLabel] = snakeLabel
+			labelOrder = append(labelOrder, trimmedLabel) // Maintain the order of labels
+		}
+	}
+	return extraLabels, labelOrder
+}
+
+// GetLabelNamesFromExtraLabels returns a slice of label names in snake_case format.
+func GetLabelNamesFromExtraLabels(extraLabels ExtraLabel) []string {
+	labelNames := make([]string, 0, len(extraLabels))
+	for _, labelValue := range extraLabels {
+		labelNames = append(labelNames, labelValue)
+	}
+	return labelNames
+}
+
+// GetExtraLabelsValues extracts values from resource labels based on extra labels.
+// If a label is missing, an empty string is added instead. It takes the label order as input.
+func GetExtraLabelsValues(resourceLabels map[string]string, extraLabels ExtraLabel, labelOrder []string) []string {
+	var labelValues []string
+	for _, key := range labelOrder { // Use the ordered list of keys
+		if value, exists := resourceLabels[key]; exists {
+			labelValues = append(labelValues, value)
+		} else {
+			labelValues = append(labelValues, "") // Add empty if label is missing
+		}
+	}
+	return labelValues
 }

--- a/pkg/pingdom-exporter/utils_test.go
+++ b/pkg/pingdom-exporter/utils_test.go
@@ -8,19 +8,19 @@ import (
 
 func TestTagLabel(t *testing.T) {
 	testCases := []struct {
-		tag string
+		tag   string
 		regex string
 	}{
 		{
-			tag: "key:value",
+			tag:   "key:value",
 			regex: "^([a-zA-Z0-9_]+):(.+)$",
 		},
 		{
-			tag: "key-value",
+			tag:   "key-value",
 			regex: "^([a-zA-Z0-9_]+)-(.+)$",
 		},
 		{
-			tag: "key@value",
+			tag:   "key@value",
 			regex: "^([a-zA-Z0-9_]+)@(.+)$",
 		},
 	}


### PR DESCRIPTION
This update introduces the ability to enhance metric label formatting and support for custom labels within the Pingdom Exporter. 

- **`-tag-extra-labels` Flag**: This new flag allows the inclusion of custom labels in the metric output. It requires the `-parser-tags` flag to be enabled and ensures that custom labels are formatted consistently with a `label_` prefix. The labels are parsed, formatted, and added to the metrics to provide more detailed and customizable monitoring data.

- **Order Preservation for Extra Labels**: The order of custom labels is guaranteed by storing the order of labels in a slice, which is then used consistently when generating metrics. This ensures that the label order remains consistent and accurate across metric reports.

- **Metrics Adjustment**: The code now includes the ability to handle and format additional tags and labels based on user input, providing more flexibility for monitoring Pingdom checks with custom label configurations.